### PR TITLE
Make client_max_body_size configuable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN rm -f /etc/nginx/conf.d/*
 
 ENV SERVER_NAME example.com
 ENV PORT 80
+ENV CLIENT_MAX_BODY_SIZE 1m
 ENV WORKER_PROCESSES auto
 
 COPY files/run.sh /

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ $ docker-compose up
 |---|---|---|
 |`SERVER_NAME`|Value for `server_name` directive|`example.com`|
 |`PORT`|Value for `listen` directive|`80`|
+|`CLIENT_MAX_BODY_SIZE`|Value for `client_max_body_size` directive|`1m`|
 |`WORKER_PROCESSES`|Value for `worker_processes` directive|`auto`|
 
 ## Author

--- a/files/nginx.conf.tmpl
+++ b/files/nginx.conf.tmpl
@@ -15,6 +15,8 @@ http {
     listen ##PORT##;
     server_name ##SERVER_NAME##;
 
+    client_max_body_size ##CLIENT_MAX_BODY_SIZE##;
+
     include /etc/nginx/conf.d/*.conf;
 
     location / {

--- a/files/run.sh
+++ b/files/run.sh
@@ -19,6 +19,7 @@ fi
 
 htpasswd -bBc /etc/nginx/.htpasswd $BASIC_AUTH_USERNAME $BASIC_AUTH_PASSWORD
 sed \
+  -e "s/##CLIENT_MAX_BODY_SIZE##/$CLIENT_MAX_BODY_SIZE/g" \
   -e "s/##WORKER_PROCESSES##/$WORKER_PROCESSES/g" \
   -e "s/##SERVER_NAME##/$SERVER_NAME/g" \
   -e "s/##PORT##/$PORT/g" \


### PR DESCRIPTION
## WHY

Sometimes we want to send a large (> 1MB) request to origin.
However if we do so actually, Nginx returns 413 error.

```html
<html>
<head><title>413 Request Entity Too Large</title></head>
<body bgcolor="white">
<center><h1>413 Request Entity Too Large</h1></center>
<hr><center>nginx/1.11.9</center>
</body>
</html>
```

Max request size is limited to 1MB in default. To configure this, we have to use `client_max_body_size` directive.
http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size

## WHAT

Add `CLIENT_MAX_BODY_SIZE` environment variable to configure `client_max_body_size` value.