### PR TITLE
Use SIGQUIT for container shutdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,8 @@ ENV WORKER_PROCESSES auto
 COPY files/run.sh /
 COPY files/nginx.conf.tmpl /
 
+# use SIGQUIT for graceful shutdown
+# c.f. http://nginx.org/en/docs/control.html
+STOPSIGNAL SIGQUIT
+
 ENTRYPOINT ["/run.sh"]


### PR DESCRIPTION
## WHY

`docker stop` sends `SIGTERM`. `SIGTERM` means "fast shutdown" in Nginx.
We prefer "graceful shutdown" (`SIGQUIT`).

## WHAT

Use `SIGQUIT` for container shutdown.

## REF
- http://nginx.org/en/docs/control.html
- https://docs.docker.com/engine/reference/builder/#stopsignal
- [Controlling nginx](http://nginx.org/en/docs/control.html)