### PR TITLE
Start Nginx process by exec command

### DIFF
--- a/files/run.sh
+++ b/files/run.sh
@@ -27,4 +27,4 @@ sed \
   -e "s|##PROXY_PASS##|$PROXY_PASS|g" \
   nginx.conf.tmpl > /etc/nginx/nginx.conf
 
-nginx -g "daemon off;"
+exec nginx -g "daemon off;"


### PR DESCRIPTION
Now exit signal to container is not propagated to Nginx process.
To do this properly, we have to start Nginx process by `exec` command.

```
2017/09/28 07:00:55 [notice] 1#1: using the "epoll" event method
2017/09/28 07:00:55 [notice] 1#1: nginx/1.11.9
2017/09/28 07:00:55 [notice] 1#1: built by gcc 5.3.0 (Alpine 5.3.0)
2017/09/28 07:00:55 [notice] 1#1: OS: Linux 4.9.49-moby
2017/09/28 07:00:55 [notice] 1#1: getrlimit(RLIMIT_NOFILE): 1048576:1048576
2017/09/28 07:00:55 [notice] 1#1: start worker processes
2017/09/28 07:00:55 [notice] 1#1: start worker process 8
2017/09/28 07:00:55 [notice] 1#1: start worker process 9
2017/09/28 07:01:00 [notice] 1#1: signal 3 (SIGQUIT) received, shutting down
2017/09/28 07:01:00 [notice] 8#8: gracefully shutting down
2017/09/28 07:01:00 [notice] 9#9: gracefully shutting down
2017/09/28 07:01:00 [notice] 8#8: exiting
2017/09/28 07:01:00 [notice] 9#9: exiting
2017/09/28 07:01:00 [notice] 8#8: exit
2017/09/28 07:01:00 [notice] 9#9: exit
2017/09/28 07:01:00 [notice] 1#1: signal 17 (SIGCHLD) received
2017/09/28 07:01:00 [notice] 1#1: worker process 9 exited with code 0
2017/09/28 07:01:00 [notice] 1#1: signal 29 (SIGIO) received
2017/09/28 07:01:00 [notice] 1#1: signal 17 (SIGCHLD) received
2017/09/28 07:01:00 [notice] 1#1: worker process 8 exited with code 0
2017/09/28 07:01:00 [notice] 1#1: exit
```